### PR TITLE
Add generic message module

### DIFF
--- a/lib/ex_rtmp/message.ex
+++ b/lib/ex_rtmp/message.ex
@@ -5,6 +5,7 @@ defmodule ExRTMP.Message do
 
   require Logger
 
+  alias __MODULE__.Command.Generic
   alias __MODULE__.Command.NetConnection.{Connect, CreateStream, Response}
   alias __MODULE__.Command.NetStream.{DeleteStream, FCPublish, OnStatus, Play, Publish}
   alias __MODULE__.Metadata
@@ -245,16 +246,6 @@ defmodule ExRTMP.Message do
     %CreateStream{transaction_id: transaction_id}
   end
 
-  defp handle_message_payload([result, transaction_id, command_object, data])
-       when result in ["_result", "_error"] do
-    %Response{
-      result: result,
-      transaction_id: trunc(transaction_id),
-      command_object: command_object,
-      data: data
-    }
-  end
-
   defp handle_message_payload(["publish", _txid, nil, name, type]), do: Publish.new(name, type)
   defp handle_message_payload(["onStatus", _txid, nil, info]), do: %OnStatus{info: info}
 
@@ -270,11 +261,27 @@ defmodule ExRTMP.Message do
     Play.new(name, play_opts)
   end
 
-  defp handle_message_payload(["deleteStream", _txid, nil, stream_id]),
-    do: DeleteStream.new(stream_id)
+  defp handle_message_payload(["deleteStream", _txid, nil, stream_id]) do
+    DeleteStream.new(stream_id)
+  end
 
-  defp handle_message_payload(["FCPublish", transaction_id, nil, name]),
-    do: FCPublish.new(transaction_id, name)
+  defp handle_message_payload(["FCPublish", transaction_id, nil, name]) do
+    FCPublish.new(transaction_id, name)
+  end
+
+  defp handle_message_payload([result, transaction_id, command_object, data])
+       when result in ["_result", "_error"] do
+    %Response{
+      result: result,
+      transaction_id: trunc(transaction_id),
+      command_object: command_object,
+      data: data
+    }
+  end
+
+  defp handle_message_payload([name, transaction_id, nil, params]) when is_binary(name) do
+    Generic.new(name, transaction_id, params)
+  end
 
   defp handle_message_payload(other) do
     Logger.warning("Unknown command: #{inspect(other)}")

--- a/lib/ex_rtmp/message/command/generic.ex
+++ b/lib/ex_rtmp/message/command/generic.ex
@@ -1,0 +1,19 @@
+defmodule ExRTMP.Message.Command.Generic do
+  @moduledoc false
+
+  # This module describe OPTIONAL command message that can be safely ignore. If
+  # for some service requires to handle these messages, we'll implement them in the future.
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          transaction_id: number(),
+          params: term()
+        }
+
+  defstruct [:name, :transaction_id, :params]
+
+  @spec new(String.t(), number(), term()) :: t()
+  def new(name, transaction_id, params) do
+    %__MODULE__{transaction_id: transaction_id, name: name, params: params}
+  end
+end

--- a/lib/ex_rtmp/message/command/generic.ex
+++ b/lib/ex_rtmp/message/command/generic.ex
@@ -1,8 +1,8 @@
 defmodule ExRTMP.Message.Command.Generic do
   @moduledoc false
 
-  # This module describe OPTIONAL command message that can be safely ignore. If
-  # for some service requires to handle these messages, we'll implement them in the future.
+  # This module describe OPTIONAL command message that can be safely ignored. If
+  # some service requires to handle/send these messages, we'll implement them.
 
   @type t :: %__MODULE__{
           name: String.t(),

--- a/lib/ex_rtmp/server/client_session.ex
+++ b/lib/ex_rtmp/server/client_session.ex
@@ -10,7 +10,7 @@ defmodule ExRTMP.Server.ClientSession do
   alias ExRTMP.ChunkParser
   alias ExRTMP.Client.MediaProcessor
   alias ExRTMP.Message
-  alias ExRTMP.Message.Command.NetConnection
+  alias ExRTMP.Message.Command.{Generic, NetConnection}
   alias ExRTMP.Message.Command.NetConnection.{CreateStream, Response}
   alias ExRTMP.Message.Command.NetStream.{DeleteStream, FCPublish, OnStatus, Play, Publish}
   alias ExRTMP.Message.Metadata
@@ -277,6 +277,10 @@ defmodule ExRTMP.Server.ClientSession do
 
         %Play{} ->
           handle_play_message(message.payload, message.stream_id, state)
+
+        %Generic{} ->
+          Logger.debug("Ignore generic message: #{inspect(message.payload)}")
+          {[], state}
 
         _other ->
           Logger.warning("Unknown command message: #{inspect(message.payload)}")


### PR DESCRIPTION
Some messages are optional or not in the standard or sent for legacy reasons, added a module to capture all of them. In case a service requires to answer or send such a message, we'll create a dedicated module.